### PR TITLE
Base 'jvmApplication' project type support

### DIFF
--- a/ecosystem-plugin/build.gradle.kts
+++ b/ecosystem-plugin/build.gradle.kts
@@ -10,6 +10,8 @@ kotlin {
 
 dependencies {
     api(project(":project-types:jvm-application"))
+
+    implementation(libs.kotlin.gradle.plugin)
 }
 
 gradlePlugin {

--- a/ecosystem-plugin/src/integrationTests/kotlin/org/jetbrains/kotlin/gradle/declarative/JvmApplicationProjectTypeTest.kt
+++ b/ecosystem-plugin/src/integrationTests/kotlin/org/jetbrains/kotlin/gradle/declarative/JvmApplicationProjectTypeTest.kt
@@ -8,10 +8,10 @@ import org.jetbrains.kotlin.gradle.declarative.testDsl.build
 import org.jetbrains.kotlin.gradle.declarative.testDsl.project
 import org.junit.jupiter.api.DisplayName
 
-@DisplayName("Smoke ecosystem plugin tests")
-class SmokeBaseTest : BaseTest() {
+@DisplayName("'jvmApplication' project type tests")
+class JvmApplicationProjectTypeTest : BaseTest() {
 
-    @DisplayName("Ecosystem plugin is applied")
+    @DisplayName("project type is applied")
     @GradleTest
     fun testEcosystemPluginIsApplied(
         gradleVersion: GradleVersion

--- a/ecosystem-plugin/src/integrationTests/resources/testProjects/base-ecosystem-project/build.gradle.dcl
+++ b/ecosystem-plugin/src/integrationTests/resources/testProjects/base-ecosystem-project/build.gradle.dcl
@@ -1,1 +1,3 @@
-//jvmApplication { }
+jvmApplication {
+
+}

--- a/ecosystem-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/JetbrainsEcosystemPlugin.kt
+++ b/ecosystem-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/JetbrainsEcosystemPlugin.kt
@@ -3,7 +3,13 @@ package org.jetbrains.kotlin.gradle.declarative
 import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
 import org.gradle.api.logging.Logging
+import org.gradle.features.annotations.RegistersProjectFeatures
+import org.jetbrains.kotlin.gradle.declarative.plugins.JetBrainsJvmApplicationPlugin
 
+@Suppress("UnstableApiUsage")
+@RegistersProjectFeatures(
+    JetBrainsJvmApplicationPlugin::class
+)
 public class JetbrainsEcosystemPlugin : Plugin<Settings> {
     private val logger = Logging.getLogger(JetbrainsEcosystemPlugin::class.java)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ kotlin = "2.3.20"
 
 [libraries]
 kotlin-gradle-plugin-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 
 [plugins]

--- a/project-types/jvm-application/build.gradle.kts
+++ b/project-types/jvm-application/build.gradle.kts
@@ -11,6 +11,8 @@ kotlin {
 
 dependencies {
     api(gradleApi())
+
+    implementation(libs.kotlin.gradle.plugin)
 }
 
 commonPublishing {

--- a/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/buildmodels/JvmApplicationBuildModel.kt
+++ b/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/buildmodels/JvmApplicationBuildModel.kt
@@ -3,5 +3,6 @@ package org.jetbrains.kotlin.gradle.declarative.buildmodels
 import org.gradle.features.binding.BuildModel
 
 
+@Suppress("UnstableApiUsage")
 public interface JvmApplicationBuildModel : BuildModel {
 }

--- a/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/plugins/JetBrainsJvmApplicationPlugin.kt
+++ b/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/plugins/JetBrainsJvmApplicationPlugin.kt
@@ -1,0 +1,41 @@
+package org.jetbrains.kotlin.gradle.declarative.plugins
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.PluginManager
+import org.gradle.features.annotations.BindsProjectType
+import org.gradle.features.binding.ProjectTypeBinding
+import org.gradle.features.binding.ProjectTypeBindingBuilder
+import org.jetbrains.kotlin.gradle.declarative.projecttypes.JvmApplicationProjectType
+import javax.inject.Inject
+
+@Suppress("UnstableApiUsage")
+@BindsProjectType(JetBrainsJvmApplicationPlugin.Binding::class)
+public abstract class JetBrainsJvmApplicationPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        println("Applying JetBrains JVM Application plugin to ${target.path}")
+    }
+
+    public class Binding : ProjectTypeBinding {
+        override fun bind(builder: ProjectTypeBindingBuilder) {
+            builder.bindProjectType(
+                "jvmApplication",
+                JvmApplicationProjectType::class.java
+            ) { context, definition, buildModel ->
+                val services = context.objectFactory.newInstance(Services::class.java)
+
+                // Recommended for now way to apply Gradle and 3rd party plugins, `apply(project)` method usage will be
+                // forbidden in the future releases
+                services.pluginManager.apply("application")
+                services.pluginManager.apply("org.jetbrains.kotlin.jvm")
+            }
+                .withUnsafeApplyAction()
+        }
+
+        internal interface Services {
+            // Unsafe service for apply action
+            @get:Inject
+            val pluginManager: PluginManager
+        }
+    }
+}

--- a/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/JvmApplicationProjectType.kt
+++ b/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/JvmApplicationProjectType.kt
@@ -3,5 +3,6 @@ package org.jetbrains.kotlin.gradle.declarative.projecttypes
 import org.gradle.features.binding.Definition
 import org.jetbrains.kotlin.gradle.declarative.buildmodels.JvmApplicationBuildModel
 
+@Suppress("UnstableApiUsage")
 public interface JvmApplicationProjectType : Definition<JvmApplicationBuildModel> {
 }


### PR DESCRIPTION
For now, it only applies KGP/JVM and Gradle 'application' plugins in the project.