### PR TITLE
Disable Gradle isolated projects feature

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
 org.gradle.configuration-cache=true
 org.gradle.caching=true
-org.gradle.unsafe.isolated-projects=true
+
+# jitpack.io is not compatible with Gradle isolated projects
+#org.gradle.unsafe.isolated-projects=true


### PR DESCRIPTION
Jitpack.io init script is not compatible with this feature as it uses '.allprojects' and tries to access mutable sub-projects state.
