### PR TITLE
Update project publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,31 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Publish to local repo
+        run: ./gradlew publishAllPublicationsToRepoLocalRepository -PprojectVersion=${PROJECT_VERSION}
+
+      - name: Checkout maven2 branch
+        uses: actions/checkout@v6
+        with:
+          ref: maven2
+          path: maven2-branch
+
+      - name: Update maven2 branch with new artifacts
+        run: |
+          rsync -av build/repo/ maven2-branch/
+
+          cd maven2-branch
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          git commit -m "New release ${PROJECT_VERSION}"
+          git push origin maven2
+
       - name: Create GitHub pre-release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,10 @@
 name: Publish
 
 on:
-  push:
+  workflow_run:
+    workflows: [ Build ]
     branches: [ main ]
+    types: [ completed ]
 
 permissions:
   contents: write
@@ -10,6 +12,7 @@ permissions:
 
 jobs:
   publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,3 @@
 org.gradle.configuration-cache=true
 org.gradle.caching=true
-
-# jitpack.io is not compatible with Gradle isolated projects
-#org.gradle.unsafe.isolated-projects=true
+org.gradle.unsafe.isolated-projects=true


### PR DESCRIPTION
- **Revert "Disable Gradle isolated projects feature"**
- **Run 'publish' workflow only when 'build' workflow succeeds**
- **Add step to commit Maven artifacts to 'maven2' branch**
