### PR TITLE
Add jarTask to the JvmApplication BuildModel

### DIFF
--- a/ecosystem-plugin/src/integrationTests/kotlin/org/jetbrains/kotlin/gradle/declarative/testDsl/BuildOptions.kt
+++ b/ecosystem-plugin/src/integrationTests/kotlin/org/jetbrains/kotlin/gradle/declarative/testDsl/BuildOptions.kt
@@ -77,7 +77,7 @@ data class BuildOptions(
         val configurationCacheFlag = configurationCache.toBooleanFlag(gradleVersion)
         if (configurationCacheFlag != null) {
             arguments.add("-Dorg.gradle.unsafe.configuration-cache=$configurationCacheFlag")
-            arguments.add("-Dorg.gradle.unsafe.configuration-cache-problems=${configurationCacheProblems.name.lowercase(Locale.getDefault())}")
+            arguments.add("-Dorg.gradle.unsafe.configuration-cache-problems=${configurationCacheProblems.name.lowercase()}")
             arguments.add("-Dorg.gradle.configuration-cache.parallel=true")
         }
 

--- a/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/jvmapplication/JvmApplicationBuildModel.kt
+++ b/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/jvmapplication/JvmApplicationBuildModel.kt
@@ -18,6 +18,7 @@ import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.bundling.Jar
 import org.gradle.features.binding.BuildModel
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainSpec
@@ -49,6 +50,7 @@ public interface JvmApplication : Named {
     public val runtimeClasspath: FileCollection
 
     public val runTask: TaskProvider<JavaExec>
+    public val jarTask: TaskProvider<Jar>
     public val executionDirectory: DirectoryProperty
 }
 
@@ -62,6 +64,7 @@ internal abstract class DefaultJvmApplication @Inject constructor(
         get() = (jvmCompilationUnit as DefaultJvmApplicationBuildModel.DefaultJvmCompilationUnit).kotlinCompilation
 
     override val runTask: TaskProvider<JavaExec> = kotlinCompilation.project.tasks.registerJvmApplicationRunTask()
+    override val jarTask: TaskProvider<Jar> = kotlinCompilation.project.tasks.named(taskName("jar"), Jar::class.java)
 
     override val runtimeOnlyConfiguration: Configuration
         get() = kotlinCompilation.project.configurations
@@ -71,7 +74,7 @@ internal abstract class DefaultJvmApplication @Inject constructor(
         get() = kotlinCompilation.runtimeDependencyFiles!!
 
     private fun TaskContainer.registerJvmApplicationRunTask(): TaskProvider<JavaExec> =
-        register(runTaskName, JavaExec::class.java) { javaExecTask ->
+        register(taskName("run"), JavaExec::class.java) { javaExecTask ->
             javaExecTask.description = "Runs this project as a JVM application"
             javaExecTask.group = ApplicationPlugin.APPLICATION_GROUP
 
@@ -93,8 +96,7 @@ internal abstract class DefaultJvmApplication @Inject constructor(
             )
         }
 
-    private val JvmApplication.runTaskName
-        get() = if (name == KotlinCompilation.MAIN_COMPILATION_NAME) "run" else "run${
+    private fun JvmApplication.taskName(name: String) = if (name == KotlinCompilation.MAIN_COMPILATION_NAME) name else "$name${
             name.replaceFirstChar {
                 if (it.isLowerCase()) it.titlecase(
                     getDefault()
@@ -197,4 +199,3 @@ internal abstract class DefaultJvmApplicationBuildModel @Inject constructor(
         }
     }
 }
-

--- a/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/jvmapplication/JvmApplicationBuildModel.kt
+++ b/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/jvmapplication/JvmApplicationBuildModel.kt
@@ -29,7 +29,6 @@ import org.jetbrains.kotlin.gradle.declarative.common.buildtypes.JvmEcosystem
 import org.jetbrains.kotlin.gradle.declarative.common.buildtypes.KotlinJvmCompilationType
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
-import java.util.Locale.getDefault
 import javax.inject.Inject
 
 @Suppress("UnstableApiUsage")
@@ -96,11 +95,9 @@ internal abstract class DefaultJvmApplication @Inject constructor(
             )
         }
 
-    private fun JvmApplication.taskName(name: String) = if (name == KotlinCompilation.MAIN_COMPILATION_NAME) name else "$name${
-            name.replaceFirstChar {
-                if (it.isLowerCase()) it.titlecase(
-                    getDefault()
-                ) else it.toString()
+    private fun JvmApplication.taskName(taskName: String) = if (name == KotlinCompilation.MAIN_COMPILATION_NAME) taskName else "$name${
+        taskName.replaceFirstChar {
+                if (it.isLowerCase()) it.uppercaseChar() else it
             }
         }"
 }


### PR DESCRIPTION
Should we also set the mainClass attribute in the Jar manifest? [Gradle does not fill it](https://github.com/gradle/gradle/issues/32263#issuecomment-3079808497)

Use-Case: I want to process the jar file to create a minimized executable jar using r8: https://github.com/hfhbd/r8/pull/28

Turns out, for my use-case, creating an executable fat jar with r8, I don't need the jar task but just the classes output of the compilations (I did it wrong in the past), but maybe other use-cases needs the jar.