### PR TITLE
Remove println

### DIFF
--- a/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/jvmapplication/JetBrainsJvmApplicationPlugin.kt
+++ b/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/jvmapplication/JetBrainsJvmApplicationPlugin.kt
@@ -39,7 +39,7 @@ import javax.inject.Inject
 @Suppress("UnstableApiUsage")
 @BindsProjectType(JetBrainsJvmApplicationPlugin.Binding::class)
 public abstract class JetBrainsJvmApplicationPlugin : Plugin<Project> {
-    override fun apply(target: Project) = Unit
+    override fun apply(target: Project) { }
 
     public class Binding : ProjectTypeBinding {
         override fun bind(builder: ProjectTypeBindingBuilder) {

--- a/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/jvmapplication/JetBrainsJvmApplicationPlugin.kt
+++ b/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/jvmapplication/JetBrainsJvmApplicationPlugin.kt
@@ -39,9 +39,7 @@ import javax.inject.Inject
 @Suppress("UnstableApiUsage")
 @BindsProjectType(JetBrainsJvmApplicationPlugin.Binding::class)
 public abstract class JetBrainsJvmApplicationPlugin : Plugin<Project> {
-    override fun apply(target: Project) {
-        println("Applying JetBrains JVM Application plugin to ${target.path}")
-    }
+    override fun apply(target: Project) = Unit
 
     public class Binding : ProjectTypeBinding {
         override fun bind(builder: ProjectTypeBindingBuilder) {


### PR DESCRIPTION
- it is annoying to read over and over
- if needed, it should use the Gradle logger
- in the future, the apply(Project) method will go away
- other `ProjectType`s do not have this logging