### PR TITLE
Add compilationUnit to JvmTestingBuildModel

### DIFF
--- a/common/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/common/definitions/TestingExtension.kt
+++ b/common/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/common/definitions/TestingExtension.kt
@@ -4,4 +4,6 @@ import org.gradle.features.binding.BuildModel
 import org.gradle.features.binding.Definition
 
 @Suppress("UnstableApiUsage")
-public interface TestingExtension : Definition<BuildModel.None>
+public interface TestingExtension<BuildModel : TestingBuildModel> : Definition<BuildModel>
+
+public interface TestingBuildModel : BuildModel

--- a/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/jvmapplication/JetBrainsJvmApplicationPlugin.kt
+++ b/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/jvmapplication/JetBrainsJvmApplicationPlugin.kt
@@ -48,6 +48,10 @@ public abstract class JetBrainsJvmApplicationPlugin : Plugin<Project> {
                 .withUnsafeApplyAction()
                 .withUnsafeDefinition()
                 .withBuildModelImplementationType(DefaultJvmApplicationBuildModel::class.java)
+                .withNestedBuildModelImplementationType(
+                    JvmTestingBuildModel::class.java,
+                    DefaultJvmTestingBuildModel::class.java,
+                )
         }
     }
 
@@ -97,6 +101,7 @@ public abstract class JetBrainsJvmApplicationPlugin : Plugin<Project> {
             kotlinJvmExtension.bindTestCompilation(
                 definition,
                 buildModel,
+                context,
             )
         }
 
@@ -223,6 +228,7 @@ public abstract class JetBrainsJvmApplicationPlugin : Plugin<Project> {
         private fun KotlinJvmExtension.bindTestCompilation(
             definition: JvmApplicationProjectType,
             buildModel: DefaultJvmApplicationBuildModel,
+            context: ProjectFeatureApplicationContext,
         ) {
             val testCompilation = target.compilations.getByName(KotlinCompilation.TEST_COMPILATION_NAME)
             project.plugins.apply("jvm-test-suite")
@@ -238,7 +244,7 @@ public abstract class JetBrainsJvmApplicationPlugin : Plugin<Project> {
                 }
             }
 
-            buildModel.compilationUnits
+            val testCompilationUnit = buildModel.compilationUnits
                 .create(KotlinCompilation.TEST_COMPILATION_NAME) { kotlinJvmCompilationUnit ->
                     kotlinJvmCompilationUnit as DefaultJvmApplicationBuildModel.DefaultJvmCompilationUnit
                     kotlinJvmCompilationUnit.kotlinCompilation = testCompilation
@@ -292,6 +298,10 @@ public abstract class JetBrainsJvmApplicationPlugin : Plugin<Project> {
                             }
                     }
                 }
+
+            val testingBuildModel = context.getBuildModel(definition.testing)
+            testingBuildModel as DefaultJvmTestingBuildModel
+            testingBuildModel.compilationUnit = testCompilationUnit
         }
     }
 }

--- a/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/jvmapplication/JvmApplicationProjectType.kt
+++ b/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/jvmapplication/JvmApplicationProjectType.kt
@@ -4,7 +4,6 @@ import org.gradle.api.tasks.Nested
 import org.gradle.features.binding.Definition
 import org.jetbrains.kotlin.gradle.declarative.common.definitions.JavaJvmCompilationExtension
 import org.jetbrains.kotlin.gradle.declarative.common.definitions.JvmEcosystemDefinition
-import org.jetbrains.kotlin.gradle.declarative.common.definitions.KotlinJvmCompilationExtension
 import org.jetbrains.kotlin.gradle.declarative.common.definitions.PackagingExtension
 
 @Suppress("UnstableApiUsage")

--- a/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/jvmapplication/JvmApplicationTestingExtension.kt
+++ b/project-types/jvm-application/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/jvmapplication/JvmApplicationTestingExtension.kt
@@ -2,12 +2,22 @@ package org.jetbrains.kotlin.gradle.declarative.projecttypes.jvmapplication
 
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Nested
+import org.jetbrains.kotlin.gradle.declarative.common.buildtypes.JvmCompilationUnit
+import org.jetbrains.kotlin.gradle.declarative.common.definitions.TestingBuildModel
 import org.jetbrains.kotlin.gradle.declarative.common.definitions.TestingExtension
 
-public interface JvmApplicationTestingExtension : TestingExtension {
+public interface JvmApplicationTestingExtension : TestingExtension<JvmTestingBuildModel> {
 
     public val useJUnitPlatform: Property<Boolean>
 
     @get:Nested
     public val dependencies: JvmApplicationTestingDependenciesExtension
+}
+
+public interface JvmTestingBuildModel : TestingBuildModel {
+    public val compilationUnit: JvmCompilationUnit
+}
+
+internal abstract class DefaultJvmTestingBuildModel : JvmTestingBuildModel {
+    override lateinit var compilationUnit: JvmCompilationUnit
 }

--- a/project-types/library/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/LibraryTestingExtension.kt
+++ b/project-types/library/src/main/kotlin/org/jetbrains/kotlin/gradle/declarative/projecttypes/LibraryTestingExtension.kt
@@ -4,9 +4,10 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Nested
 import org.gradle.features.binding.BuildModel
 import org.gradle.features.binding.Definition
+import org.jetbrains.kotlin.gradle.declarative.common.definitions.TestingBuildModel
 import org.jetbrains.kotlin.gradle.declarative.common.definitions.TestingExtension
 
-public interface LibraryTestingExtension : TestingExtension {
+public interface LibraryTestingExtension : TestingExtension<LibraryTestingBuildModel> {
 
     @get:Nested
     public val dependencies: LibraryTestingDependenciesExtension
@@ -20,6 +21,8 @@ public interface LibraryTestingExtension : TestingExtension {
     @get:Nested
     public val iosPlatform: LibraryTestingIosEcosystemDefinition
 }
+
+public interface LibraryTestingBuildModel : TestingBuildModel
 
 @Suppress("UnstableApiUsage")
 public interface LibraryTestingJvmEcosystemDefinition : Definition<BuildModel.None> {


### PR DESCRIPTION
Fixes #66

Without test-suites, there is only 1 compilationUnit: `test`